### PR TITLE
Add reportes page with API client

### DIFF
--- a/ce-english/src/components/Navbar.jsx
+++ b/ce-english/src/components/Navbar.jsx
@@ -27,7 +27,7 @@ export default function Navbar() {
     <header className={styles.root}>
       <div className={styles.container}>
         <Link to={isLogin ? '/' : '/dashboard'} className={styles.logo}>
-          C&E English
+          C&E English
         </Link>
 
         {/* Muestra el resto solo si no es la página de login */}
@@ -47,6 +47,7 @@ export default function Navbar() {
               <NavLink to="/dashboard"  onClick={() => setOpen(false)}>Dashboard</NavLink>
               <NavLink to="/clases"     onClick={() => setOpen(false)}>Clases</NavLink>
               <NavLink to="/asistencia" onClick={() => setOpen(false)}>Asistencia</NavLink>
+              <NavLink to="/reportes"  onClick={() => setOpen(false)}>Reportes</NavLink>
               <NavLink to="/perfil"     onClick={() => setOpen(false)}>Perfil</NavLink>
               <button className={styles.logout} onClick={logout}>Salir</button>
             </nav>

--- a/ce-english/src/context/AuthContext.jsx
+++ b/ce-english/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 // src/context/AuthContext.jsx
-import { createContext, useContext, useState } from 'react';
+import { createContext, useState } from 'react';
 
 export const AuthContext = createContext(null);
 

--- a/ce-english/src/pages/Login.jsx
+++ b/ce-english/src/pages/Login.jsx
@@ -19,7 +19,8 @@ export default function Login() {
       const data = await loginRequest(credentials); // { token, user }
       login(data);                                  // guarda token + user
       navigate('/dashboard');
-    } catch (err) {
+    } catch (e) {
+      console.error(e);
       setError('Credenciales inválidas');
     } finally {
       setLoading(false);

--- a/ce-english/src/pages/Reportes.jsx
+++ b/ce-english/src/pages/Reportes.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import useAuth from '../hooks/useAuth';
+import { fetchReporteClase } from '../services/api';
+import Spinner from '../components/Spinner';
+
+export default function Reportes() {
+  const { user } = useAuth();
+  const [claseId, setClaseId] = useState('');
+  const [reporte, setReporte] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleConsultar = async () => {
+    if (!claseId) return;
+    setLoading(true);
+    try {
+      const data = await fetchReporteClase(claseId, user.token);
+      setReporte(data);
+    } catch (err) {
+      console.error('Error consultando reporte:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section style={{ padding: '1rem' }}>
+      <h2>Reportes</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="number"
+          placeholder="ID de clase"
+          value={claseId}
+          onChange={(e) => setClaseId(e.target.value)}
+        />
+        <button onClick={handleConsultar} style={{ marginLeft: '0.5rem' }}>
+          Consultar
+        </button>
+      </div>
+      {loading && <Spinner />}
+      {reporte && (
+        <pre style={{ whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify(reporte, null, 2)}
+        </pre>
+      )}
+    </section>
+  );
+}

--- a/ce-english/src/routes/AppRouter.jsx
+++ b/ce-english/src/routes/AppRouter.jsx
@@ -4,6 +4,7 @@ import Dashboard from '../pages/Dashboard.jsx';
 import Clases from '../pages/Clases.jsx';
 import Asistencia from '../pages/Asistencia.jsx';
 import Perfil from '../pages/Perfil.jsx';
+import Reportes from '../pages/Reportes.jsx';
 import ProtectedRoute from './ProtectedRoute.jsx';
 
 export default function AppRouter() {
@@ -31,6 +32,14 @@ export default function AppRouter() {
         element={
           <ProtectedRoute>
             <Asistencia />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/reportes"
+        element={
+          <ProtectedRoute>
+            <Reportes />
           </ProtectedRoute>
         }
       />

--- a/ce-english/src/services/api.js
+++ b/ce-english/src/services/api.js
@@ -64,5 +64,18 @@ export const fetchUsuario = async (id, token) => {
   return data;  // { id, nombre, email, rol, ... }
 };
 
+// ─── Reportes ───────────────────────────────────
+/**
+ * Resumen de asistencia por clase
+ * GET /api/reportes/asistencia/clase/:claseId
+ */
+export const fetchReporteClase = async (claseId, token, params = {}) => {
+  const { data } = await api.get(`/reportes/asistencia/clase/${claseId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  });
+  return data;
+};
+
 
 export default api;


### PR DESCRIPTION
## Summary
- create `Reportes` page to query class reports
- expose `fetchReporteClase` API helper
- add `/reportes` route and nav link
- clean up `AuthContext` import and minor fixes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f516f467483229fab242cefa5c473