### PR TITLE
Enable admin creation forms

### DIFF
--- a/ce-english/src/components/Navbar.jsx
+++ b/ce-english/src/components/Navbar.jsx
@@ -27,7 +27,7 @@ export default function Navbar() {
     <header className={styles.root}>
       <div className={styles.container}>
         <Link to={isLogin ? '/' : '/dashboard'} className={styles.logo}>
-          C&E English
+          C&E English
         </Link>
 
         {/* Muestra el resto solo si no es la página de login */}
@@ -47,6 +47,8 @@ export default function Navbar() {
               <NavLink to="/dashboard"  onClick={() => setOpen(false)}>Dashboard</NavLink>
               <NavLink to="/clases"     onClick={() => setOpen(false)}>Clases</NavLink>
               <NavLink to="/asistencia" onClick={() => setOpen(false)}>Asistencia</NavLink>
+              <NavLink to="/reportes"  onClick={() => setOpen(false)}>Reportes</NavLink>
+              <NavLink to="/admin"     onClick={() => setOpen(false)}>Admin</NavLink>
               <NavLink to="/perfil"     onClick={() => setOpen(false)}>Perfil</NavLink>
               <button className={styles.logout} onClick={logout}>Salir</button>
             </nav>

--- a/ce-english/src/context/AuthContext.jsx
+++ b/ce-english/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 // src/context/AuthContext.jsx
-import { createContext, useContext, useState } from 'react';
+import { createContext, useState } from 'react';
 
 export const AuthContext = createContext(null);
 

--- a/ce-english/src/pages/Admin.jsx
+++ b/ce-english/src/pages/Admin.jsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react';
+import useAuth from '../hooks/useAuth';
+import {
+  registerUser,
+  createAlumno,
+  createClase,
+  enrollAlumno,
+  fetchClases,
+  fetchAlumnos,
+  fetchUsuarios,
+} from '../services/api';
+import Spinner from '../components/Spinner';
+import styles from './Login.module.css';
+
+export default function Admin() {
+  const { user } = useAuth();
+  const token = user?.token;
+
+  // datos auxiliares
+  const [docentes, setDocentes] = useState([]);
+  const [clases, setClases] = useState([]);
+  const [alumnos, setAlumnos] = useState([]);
+  const [loadingData, setLoadingData] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+    const load = async () => {
+      try {
+        const [u, c, a] = await Promise.all([
+          fetchUsuarios(token),
+          fetchClases(token),
+          fetchAlumnos(token),
+        ]);
+        setDocentes(u.filter((us) => us.rol === 'docente'));
+        setClases(c);
+        setAlumnos(a);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoadingData(false);
+      }
+    };
+    load();
+  }, [token]);
+
+  // ------ Estados de formularios ------
+  const [uNombre, setUNombre] = useState('');
+  const [uEmail, setUEmail] = useState('');
+  const [uPassword, setUPassword] = useState('');
+  const [uRol, setURol] = useState('docente');
+  const [uLoading, setULoading] = useState(false);
+
+  const [aNombre, setANombre] = useState('');
+  const [aEmail, setAEmail] = useState('');
+  const [aTelefono, setATelefono] = useState('');
+  const [aLoading, setALoading] = useState(false);
+
+  const [cNombre, setCNombre] = useState('');
+  const [cDocente, setCDocente] = useState('');
+  const [cLoading, setCLoading] = useState(false);
+
+  const [insClase, setInsClase] = useState('');
+  const [insAlumno, setInsAlumno] = useState('');
+  const [iLoading, setILoading] = useState(false);
+
+  // ------ Handlers ------
+  const handleUser = async (e) => {
+    e.preventDefault();
+    setULoading(true);
+    try {
+      await registerUser({ nombre: uNombre, email: uEmail, password: uPassword, rol: uRol }, token);
+      alert('Usuario registrado');
+      setUNombre('');
+      setUEmail('');
+      setUPassword('');
+      setURol('docente');
+    } catch (err) {
+      console.error(err);
+      alert('Error al registrar usuario');
+    } finally {
+      setULoading(false);
+    }
+  };
+
+  const handleAlumno = async (e) => {
+    e.preventDefault();
+    setALoading(true);
+    try {
+      await createAlumno({ nombre: aNombre, email: aEmail, telefono: aTelefono }, token);
+      alert('Alumno creado');
+      setANombre('');
+      setAEmail('');
+      setATelefono('');
+      const lista = await fetchAlumnos(token);
+      setAlumnos(lista);
+    } catch (err) {
+      console.error(err);
+      alert('Error al crear alumno');
+    } finally {
+      setALoading(false);
+    }
+  };
+
+  const handleClase = async (e) => {
+    e.preventDefault();
+    setCLoading(true);
+    try {
+      await createClase({ nombre: cNombre, docente_id: Number(cDocente) }, token);
+      alert('Clase creada');
+      setCNombre('');
+      setCDocente('');
+      const lista = await fetchClases(token);
+      setClases(lista);
+    } catch (err) {
+      console.error(err);
+      alert('Error al crear clase');
+    } finally {
+      setCLoading(false);
+    }
+  };
+
+  const handleInscribir = async (e) => {
+    e.preventDefault();
+    setILoading(true);
+    try {
+      await enrollAlumno(insClase, insAlumno, token);
+      alert('Alumno inscrito');
+    } catch (err) {
+      console.error(err);
+      alert('Error al inscribir');
+    } finally {
+      setILoading(false);
+    }
+  };
+
+  if (loadingData) return <Spinner />;
+
+  return (
+    <section style={{ padding: '1rem' }}>
+      <h2>Administrar</h2>
+
+      <form className={styles.root} onSubmit={handleUser} style={{ marginBottom: '2rem' }}>
+        <h3 className={styles.title}>Registrar usuario</h3>
+        <div className={styles.field}>
+          <label className={styles.label}>Nombre</label>
+          <input className={styles.input} value={uNombre} onChange={e => setUNombre(e.target.value)} required />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Email</label>
+          <input className={styles.input} type="email" value={uEmail} onChange={e => setUEmail(e.target.value)} required />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Contraseña</label>
+          <input className={styles.input} type="password" value={uPassword} onChange={e => setUPassword(e.target.value)} required />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Rol</label>
+          <select className={styles.input} value={uRol} onChange={e => setURol(e.target.value)}>
+            <option value="admin">Admin</option>
+            <option value="docente">Docente</option>
+          </select>
+        </div>
+        <button className={styles.button} disabled={uLoading}>{uLoading ? '...' : 'Crear usuario'}</button>
+      </form>
+
+      <form className={styles.root} onSubmit={handleAlumno} style={{ marginBottom: '2rem' }}>
+        <h3 className={styles.title}>Crear alumno</h3>
+        <div className={styles.field}>
+          <label className={styles.label}>Nombre</label>
+          <input className={styles.input} value={aNombre} onChange={e => setANombre(e.target.value)} required />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Email</label>
+          <input className={styles.input} type="email" value={aEmail} onChange={e => setAEmail(e.target.value)} required />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Teléfono</label>
+          <input className={styles.input} value={aTelefono} onChange={e => setATelefono(e.target.value)} />
+        </div>
+        <button className={styles.button} disabled={aLoading}>{aLoading ? '...' : 'Crear alumno'}</button>
+      </form>
+
+      <form className={styles.root} onSubmit={handleClase} style={{ marginBottom: '2rem' }}>
+        <h3 className={styles.title}>Crear clase</h3>
+        <div className={styles.field}>
+          <label className={styles.label}>Nombre</label>
+          <input className={styles.input} value={cNombre} onChange={e => setCNombre(e.target.value)} required />
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Docente</label>
+          <select className={styles.input} value={cDocente} onChange={e => setCDocente(e.target.value)} required>
+            <option value="">Selecciona un docente</option>
+            {docentes.map(d => (
+              <option key={d.id} value={d.id}>{d.nombre}</option>
+            ))}
+          </select>
+        </div>
+        <button className={styles.button} disabled={cLoading}>{cLoading ? '...' : 'Crear clase'}</button>
+      </form>
+
+      <form className={styles.root} onSubmit={handleInscribir}>
+        <h3 className={styles.title}>Inscribir alumno</h3>
+        <div className={styles.field}>
+          <label className={styles.label}>Clase</label>
+          <select className={styles.input} value={insClase} onChange={e => setInsClase(e.target.value)} required>
+            <option value="">Selecciona una clase</option>
+            {clases.map(c => (
+              <option key={c.id} value={c.id}>{c.nombre}</option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.field}>
+          <label className={styles.label}>Alumno</label>
+          <select className={styles.input} value={insAlumno} onChange={e => setInsAlumno(e.target.value)} required>
+            <option value="">Selecciona un alumno</option>
+            {alumnos.map(a => (
+              <option key={a.id} value={a.id}>{a.nombre}</option>
+            ))}
+          </select>
+        </div>
+        <button className={styles.button} disabled={iLoading}>{iLoading ? '...' : 'Inscribir'}</button>
+      </form>
+    </section>
+  );
+}

--- a/ce-english/src/pages/Asistencia.jsx
+++ b/ce-english/src/pages/Asistencia.jsx
@@ -1,38 +1,3 @@
-// import { useEffect, useState } from 'react';
-// import useAuth from '../hooks/useAuth';
-// import { fetchAttendanceByClass, sendAttendance, fetchClases } from '../services/api';
-// import AttendanceForm from '../components/AttendanceForm';
-// import Spinner from '../components/Spinner';
-// export default function Asistencia() {
-//   const { user } = useAuth();
-//   const [clases, setClases] = useState([]);
-//   const [selectedClass, setSelectedClass] = useState('');
-//   const [alumnos, setAlumnos] = useState([]);
-//   const [loading, setLoading] = useState(false);
-
-//   useEffect(()=> { fetchClases(user.token).then(setClases); }, [user]);
-//   const loadAlumnos = async (id) => { setLoading(true); const data = await fetchAttendanceByClass(id, user.token); setAlumnos(data); setLoading(false); };
-//   const togglePresente = (id) => setAlumnos(prev=>prev.map(a=> a.id===id? {...a, presente:!a.presente}:a));
-//   const handleSubmit = async () => { await sendAttendance(selectedClass, alumnos, user.token); alert('Asistencia enviada'); };
-
-//   return (
-//     <section style={{padding:'1rem'}}>
-//       <h2>Asistencia</h2>
-//       <select value={selectedClass} onChange={e=>{ const id=e.target.value; setSelectedClass(id); if(id) loadAlumnos(id); }}>
-//         <option value="">Selecciona una clase</option>
-//         {clases.map(c=> <option key={c.id} value={c.id}>{c.nombre}</option>)}
-//       </select>
-//       {loading && <Spinner />}
-//       {alumnos.length > 0 && (
-//         <>
-//           <AttendanceForm alumnos={alumnos} onToggle={togglePresente} />
-//           <button style={{marginTop:'1rem'}} onClick={handleSubmit}>Enviar asistencia</button>
-//         </>
-//       )}
-//     </section>
-//   );
-// }
-// src/pages/Asistencia.jsx
 import { useState, useEffect } from 'react';
 import useAuth from '../hooks/useAuth';
 import ClassSelect from '../components/ClassSelect';

--- a/ce-english/src/pages/Login.jsx
+++ b/ce-english/src/pages/Login.jsx
@@ -19,7 +19,8 @@ export default function Login() {
       const data = await loginRequest(credentials); // { token, user }
       login(data);                                  // guarda token + user
       navigate('/dashboard');
-    } catch (err) {
+    } catch (e) {
+      console.error(e);
       setError('Credenciales inválidas');
     } finally {
       setLoading(false);

--- a/ce-english/src/pages/Reportes.jsx
+++ b/ce-english/src/pages/Reportes.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import useAuth from '../hooks/useAuth';
+import { fetchReporteClase } from '../services/api';
+import Spinner from '../components/Spinner';
+
+export default function Reportes() {
+  const { user } = useAuth();
+  const [claseId, setClaseId] = useState('');
+  const [reporte, setReporte] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleConsultar = async () => {
+    if (!claseId) return;
+    setLoading(true);
+    try {
+      const data = await fetchReporteClase(claseId, user.token);
+      setReporte(data);
+    } catch (err) {
+      console.error('Error consultando reporte:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section style={{ padding: '1rem' }}>
+      <h2>Reportes</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="number"
+          placeholder="ID de clase"
+          value={claseId}
+          onChange={(e) => setClaseId(e.target.value)}
+        />
+        <button onClick={handleConsultar} style={{ marginLeft: '0.5rem' }}>
+          Consultar
+        </button>
+      </div>
+      {loading && <Spinner />}
+      {reporte && (
+        <pre style={{ whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify(reporte, null, 2)}
+        </pre>
+      )}
+    </section>
+  );
+}

--- a/ce-english/src/routes/AppRouter.jsx
+++ b/ce-english/src/routes/AppRouter.jsx
@@ -4,6 +4,8 @@ import Dashboard from '../pages/Dashboard.jsx';
 import Clases from '../pages/Clases.jsx';
 import Asistencia from '../pages/Asistencia.jsx';
 import Perfil from '../pages/Perfil.jsx';
+import Reportes from '../pages/Reportes.jsx';
+import Admin from '../pages/Admin.jsx';
 import ProtectedRoute from './ProtectedRoute.jsx';
 
 export default function AppRouter() {
@@ -31,6 +33,22 @@ export default function AppRouter() {
         element={
           <ProtectedRoute>
             <Asistencia />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/reportes"
+        element={
+          <ProtectedRoute>
+            <Reportes />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/admin"
+        element={
+          <ProtectedRoute>
+            <Admin />
           </ProtectedRoute>
         }
       />

--- a/ce-english/src/services/api.js
+++ b/ce-english/src/services/api.js
@@ -64,5 +64,70 @@ export const fetchUsuario = async (id, token) => {
   return data;  // { id, nombre, email, rol, ... }
 };
 
+// ─── Reportes ───────────────────────────────────
+/**
+ * Resumen de asistencia por clase
+ * GET /api/reportes/asistencia/clase/:claseId
+ */
+export const fetchReporteClase = async (claseId, token, params = {}) => {
+  const { data } = await api.get(`/reportes/asistencia/clase/${claseId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  });
+  return data;
+};
+
+// ─── Usuarios ───────────────────────────────────
+/**
+ * Registrar usuario (admin o docente)
+ * POST /api/auth/register
+ */
+export const registerUser = async (payload, token) => {
+  const { data } = await api.post('/auth/register', payload, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  return data;
+};
+
+/** Obtener lista de usuarios */
+export const fetchUsuarios = async (token) => {
+  const { data } = await api.get('/usuarios', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};
+
+// ─── Alumnos ────────────────────────────────────
+export const createAlumno = async (payload, token) => {
+  const { data } = await api.post('/alumnos', payload, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};
+
+export const fetchAlumnos = async (token) => {
+  const { data } = await api.get('/alumnos', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};
+
+// ─── Clases ─────────────────────────────────────
+export const createClase = async (payload, token) => {
+  const { data } = await api.post('/clases', payload, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};
+
+export const enrollAlumno = async (claseId, alumno_id, token) => {
+  const { data } = await api.post(
+    `/clases/${claseId}/alumnos`,
+    { alumno_id },
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return data;
+};
+
 
 export default api;


### PR DESCRIPTION
## Summary
- add admin page with forms to register users, students, classes and enrollments
- expose creation functions in the API service
- register new route and link from the navbar

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f516f467483229fab242cefa5c473