### PR TITLE
chore: rename client script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Tomar Lista
+
+## Comandos de inicio
+
+- `npm run ce-english`: inicia el frontend (CE English).
+- `npm run server`: inicia el backend.
+- `npm run dev`: inicia ambos servicios en paralelo.
+

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "scripts": {
-        "client": "cd client && npm run dev",
+        "ce-english": "cd ce-english && npm run dev",
         "server": "cd server && npm run dev",
-        "dev": "concurrently \"npm run client\" \"npm run server\""
+        "dev": "concurrently \"npm run ce-english\" \"npm run server\""
     },
     "devDependencies": {
         "concurrently": "^9.1.2"


### PR DESCRIPTION
## Summary
- rename `client` script to `ce-english`
- document project start commands

## Testing
- `npm run dev`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a890d4b8d08322a53eaca7bf222122